### PR TITLE
CI: initial version Docker build job

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,43 @@
+---
+name: "Build MSL-API image and push it to registry"
+
+on:
+  push:
+    branches:
+      - 'development'
+      - 'dev-update-docker'
+
+jobs:
+  push-image:
+    if: github.repository == 'utrechtuniversity/msl_api'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      id: extract_branch
+
+    - name: Check out EPOS-MSL catalog repository
+      uses: actions/checkout@v4
+      with:
+        path: epos-msl
+        repository: UtrechtUniversity/epos-msl
+        ref: ${{ steps.extract_branch.outputs.branch }}
+
+    - name: Authenticate to the container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: epos-msl/docker/images/msl-api
+        file: epos-msl/docker/images/msl-api/Dockerfile
+        push: true
+        tags: ghcr.io/utrechtuniversity/epos-msl-cat-mslapi:latest


### PR DESCRIPTION
This initial version of the job only publishes containers based on development versions of MSL-API. This version does not allow for release images yet.